### PR TITLE
Fixing another bug in the HTML editor

### DIFF
--- a/src/components/controls/HTMLEditor.vue
+++ b/src/components/controls/HTMLEditor.vue
@@ -114,6 +114,8 @@ export default {
     },
     watch: {
         value(newValue) {
+            if (newValue === this.editor.getHTML()) return;
+            
             this.editor.setContent(newValue)
         }
     }


### PR DESCRIPTION
When typing, it would trigger setContent() which would move the cursor to the end